### PR TITLE
Implement PRD orchestration flows and service integrations

### DIFF
--- a/odysseia/agent_manager/main.py
+++ b/odysseia/agent_manager/main.py
@@ -1,31 +1,106 @@
+import os
+from typing import Any
+
+import httpx
 from fastapi import FastAPI
 from pydantic import BaseModel
-import httpx
 
 app = FastAPI()
 
-class AgentRequest(BaseModel):
-    prompt: str
+
+class LayerBinding(BaseModel):
+    layer: str
+    service: str
+    endpoint: str
+
+
+class ConversationRequest(BaseModel):
+    user_id: str
+    utterance: str
+    persona_id: str | None = None
+    emotional_state: str | None = None
+    voice_input_url: str | None = None
+
+
+class TaskExecutionRequest(BaseModel):
+    user_id: str
+    goal: str
+    context: dict | None = None
+
+
+class OpportunityRequest(BaseModel):
+    user_id: str
+    context: dict | None = None
+
+
+MENTIS_URL = os.getenv("MENTIS_URL", "http://mentis:8000")
+CHRONOS_URL = os.getenv("CHRONOS_URL", "http://chronos:8000")
+INWORLD_URL = os.getenv("INWORLD_URL", "http://inworld:8080")
+ELEVENLABS_URL = os.getenv("ELEVENLABS_URL", "http://elevenlabs:8080")
+GEMINI_URL = os.getenv("GEMINI_URL", "http://gemini:8080")
+SESAME_URL = os.getenv("SESAME_URL", "http://sesame:8080")
+REVETA_URL = os.getenv("REVETA_URL", "http://reveta:8080")
+
 
 @app.get("/health")
 def health():
     return {"status": "ok"}
 
-@app.post("/mentis/strategy")
-async def mentis_strategy(req: AgentRequest):
-    async with httpx.AsyncClient() as client:
-        resp = await client.post("http://mentis:8000/strategy", json={"prompt": req.prompt})
-        return resp.json()
 
-@app.post("/chronos/plan")
-async def chronos_plan(req: AgentRequest):
-    async with httpx.AsyncClient() as client:
-        resp = await client.post("http://chronos:8000/plan", json={"prompt": req.prompt})
-        return resp.json()
+@app.get("/layers", response_model=list[LayerBinding])
+def layer_map():
+    return [
+        LayerBinding(layer="Inworld persona", service="inworld", endpoint=f"{INWORLD_URL}/dialog"),
+        LayerBinding(layer="ElevenLabs voice I/O", service="elevenlabs", endpoint=f"{ELEVENLABS_URL}/synthesize"),
+        LayerBinding(layer="Gemini 3 cognitive core", service="gemini", endpoint=f"{GEMINI_URL}/reason"),
+        LayerBinding(layer="Sesame execution", service="sesame", endpoint=f"{SESAME_URL}/execute"),
+        LayerBinding(layer="Reveta data layer", service="reveta", endpoint=f"{REVETA_URL}/memory"),
+        LayerBinding(
+            layer="Odysseia narrative", service="agent_manager", endpoint="/conversation|/tasks/execute|/opportunities"
+        ),
+    ]
 
-@app.post("/orchestrate")
-async def orchestrate(req: AgentRequest):
+
+async def _forward(client: httpx.AsyncClient, url: str, payload: dict) -> Any:
+    resp = await client.post(url, json=payload)
+    resp.raise_for_status()
+    return resp.json()
+
+
+@app.post("/conversation")
+async def orchestrate_conversation(req: ConversationRequest):
     async with httpx.AsyncClient() as client:
-        strat = await client.post("http://mentis:8000/strategy", json={"prompt": req.prompt})
-        plan = await client.post("http://chronos:8000/plan", json={"prompt": req.prompt})
-        return {"strategy": strat.json().get("strategy"), "plan": plan.json().get("plan")}
+        mentis_response = await _forward(client, f"{MENTIS_URL}/conversation", req.dict())
+        return {
+            "narrative_layer": {
+                "persona_reply": mentis_response.get("persona_response", {}),
+                "reasoning": mentis_response.get("reasoning"),
+            },
+            "memory_reference": mentis_response.get("memory_reference"),
+        }
+
+
+@app.post("/tasks/execute")
+async def orchestrate_task(req: TaskExecutionRequest):
+    async with httpx.AsyncClient() as client:
+        chronos_response = await _forward(client, f"{CHRONOS_URL}/tasks/execute", req.dict())
+        return {
+            "narrative_layer": {
+                "plan": chronos_response.get("plan"),
+                "execution": chronos_response.get("sesame_receipt"),
+            },
+            "memory_reference": chronos_response.get("memory_reference"),
+        }
+
+
+@app.post("/opportunities")
+async def orchestrate_opportunities(req: OpportunityRequest):
+    async with httpx.AsyncClient() as client:
+        chronos_response = await _forward(client, f"{CHRONOS_URL}/opportunities", req.dict())
+        return {
+            "narrative_layer": {
+                "opportunities": chronos_response.get("opportunities"),
+                "reasoning": chronos_response.get("reasoning"),
+            },
+            "memory_reference": chronos_response.get("memory_reference"),
+        }

--- a/odysseia/chronos/main.py
+++ b/odysseia/chronos/main.py
@@ -1,19 +1,95 @@
+import os
+
+import httpx
 from fastapi import FastAPI
 from pydantic import BaseModel
 
 app = FastAPI()
 
-class PlanRequest(BaseModel):
-    prompt: str
 
-class PlanResponse(BaseModel):
-    plan: str
+class TaskExecutionRequest(BaseModel):
+    user_id: str
+    goal: str
+    context: dict | None = None
+
+
+class TaskExecutionResponse(BaseModel):
+    plan: dict
+    sesame_receipt: dict
+    memory_reference: str
+
+
+class OpportunityRequest(BaseModel):
+    user_id: str
+    context: dict | None = None
+
+
+class OpportunityResponse(BaseModel):
+    opportunities: list[dict]
+    reasoning: str
+    memory_reference: str
+
+
+GEMINI_URL = os.getenv("GEMINI_URL", "http://gemini:8080")
+SESAME_URL = os.getenv("SESAME_URL", "http://sesame:8080")
+REVETA_URL = os.getenv("REVETA_URL", "http://reveta:8080")
+
 
 @app.get("/health")
 def health():
     return {"status": "ok"}
 
-@app.post("/plan", response_model=PlanResponse)
-def get_plan(req: PlanRequest):
-    # Mocked planning
-    return {"plan": f"Timeline and plan for: {req.prompt}"}
+
+async def _ask_gemini_for_plan(client: httpx.AsyncClient, goal: str, context: dict | None) -> dict:
+    resp = await client.post(f"{GEMINI_URL}/plan", json={"goal": goal, "context": context, "long_context": True})
+    return resp.json().get("plan", {})
+
+
+async def _dispatch_to_sesame(client: httpx.AsyncClient, plan: dict, user_id: str) -> dict:
+    resp = await client.post(f"{SESAME_URL}/execute", json={"plan": plan, "user_id": user_id})
+    return resp.json()
+
+
+async def _save_memory(client: httpx.AsyncClient, user_id: str, payload: dict) -> str:
+    resp = await client.post(f"{REVETA_URL}/memory", json={"user_id": user_id, "interaction": payload})
+    return resp.json().get("memory_id", "")
+
+
+async def _find_opportunities(client: httpx.AsyncClient, user_id: str, context: dict | None) -> tuple[list[dict], dict]:
+    resp = await client.post(
+        f"{GEMINI_URL}/opportunities",
+        json={"user_id": user_id, "context": context, "long_context": True},
+    )
+    data = resp.json()
+    return data.get("opportunities", []), data
+
+
+@app.post("/tasks/execute", response_model=TaskExecutionResponse)
+async def execute_task(req: TaskExecutionRequest):
+    async with httpx.AsyncClient() as client:
+        plan = await _ask_gemini_for_plan(client, req.goal, req.context)
+        sesame_receipt = await _dispatch_to_sesame(client, plan, req.user_id)
+        memory_reference = await _save_memory(
+            client,
+            user_id=req.user_id,
+            payload={"plan": plan, "execution": sesame_receipt, "context": req.context},
+        )
+
+        return TaskExecutionResponse(plan=plan, sesame_receipt=sesame_receipt, memory_reference=memory_reference)
+
+
+@app.post("/opportunities", response_model=OpportunityResponse)
+async def opportunity_flow(req: OpportunityRequest):
+    async with httpx.AsyncClient() as client:
+        opportunities, reasoning = await _find_opportunities(client, req.user_id, req.context)
+        memory_reference = await _save_memory(
+            client,
+            user_id=req.user_id,
+            payload={"opportunities": opportunities, "reasoning": reasoning},
+        )
+
+        return OpportunityResponse(
+            opportunities=opportunities,
+            reasoning=reasoning.get("thought", ""),
+            memory_reference=memory_reference,
+        )

--- a/odysseia/chronos/requirements.txt
+++ b/odysseia/chronos/requirements.txt
@@ -1,2 +1,3 @@
 fastapi
 uvicorn[standard]
+httpx

--- a/odysseia/mentis/main.py
+++ b/odysseia/mentis/main.py
@@ -1,19 +1,115 @@
+import os
+
+import httpx
 from fastapi import FastAPI
 from pydantic import BaseModel
 
 app = FastAPI()
 
-class StrategyRequest(BaseModel):
-    prompt: str
 
-class StrategyResponse(BaseModel):
-    strategy: str
+class ConversationRequest(BaseModel):
+    user_id: str
+    utterance: str
+    persona_id: str | None = None
+    emotional_state: str | None = None
+    voice_input_url: str | None = None
+
+
+class ConversationTurn(BaseModel):
+    text: str
+    voice_url: str | None = None
+    emotion: str | None = None
+
+
+class ConversationResponse(BaseModel):
+    persona_response: ConversationTurn
+    reasoning: str
+    memory_reference: str
+
+
+ELEVENLABS_URL = os.getenv("ELEVENLABS_URL", "http://elevenlabs:8080")
+INWORLD_URL = os.getenv("INWORLD_URL", "http://inworld:8080")
+GEMINI_URL = os.getenv("GEMINI_URL", "http://gemini:8080")
+REVETA_URL = os.getenv("REVETA_URL", "http://reveta:8080")
+
 
 @app.get("/health")
 def health():
     return {"status": "ok"}
 
-@app.post("/strategy", response_model=StrategyResponse)
-def get_strategy(req: StrategyRequest):
-    # Mocked strategic guidance
-    return {"strategy": f"Strategic guidance for: {req.prompt}"}
+
+async def _transcribe_voice(client: httpx.AsyncClient, audio_url: str | None, fallback: str) -> str:
+    if not audio_url:
+        return fallback
+
+    resp = await client.post(f"{ELEVENLABS_URL}/transcribe", json={"audio_url": audio_url})
+    data = resp.json()
+    return data.get("text", fallback)
+
+
+async def _send_to_inworld(client: httpx.AsyncClient, text: str, persona_id: str | None, emotion: str | None) -> dict:
+    payload = {"text": text, "emotion": emotion}
+    if persona_id:
+        payload["persona_id"] = persona_id
+
+    resp = await client.post(f"{INWORLD_URL}/dialog", json=payload)
+    return resp.json()
+
+
+async def _reason_with_gemini(client: httpx.AsyncClient, user_id: str, utterance: str, persona_reply: str) -> dict:
+    resp = await client.post(
+        f"{GEMINI_URL}/reason",
+        json={
+            "user_id": user_id,
+            "prompt": utterance,
+            "assistant_reply": persona_reply,
+            "long_context": True,
+        },
+    )
+    return resp.json()
+
+
+async def _persist_memory(client: httpx.AsyncClient, user_id: str, interaction: dict) -> str:
+    resp = await client.post(f"{REVETA_URL}/memory", json={"user_id": user_id, "interaction": interaction})
+    data = resp.json()
+    return data.get("memory_id", "")
+
+
+async def _synthesize_voice(client: httpx.AsyncClient, text: str, emotion: str | None) -> str | None:
+    resp = await client.post(f"{ELEVENLABS_URL}/synthesize", json={"text": text, "emotion": emotion})
+    data = resp.json()
+    return data.get("audio_url")
+
+
+@app.post("/conversation", response_model=ConversationResponse)
+async def handle_conversation(req: ConversationRequest):
+    async with httpx.AsyncClient() as client:
+        spoken_text = await _transcribe_voice(client, req.voice_input_url, req.utterance)
+        persona_result = await _send_to_inworld(client, spoken_text, req.persona_id, req.emotional_state)
+
+        reasoning = await _reason_with_gemini(
+            client, user_id=req.user_id, utterance=spoken_text, persona_reply=persona_result.get("reply", "")
+        )
+
+        memory_id = await _persist_memory(
+            client,
+            user_id=req.user_id,
+            interaction={
+                "user": spoken_text,
+                "assistant": persona_result.get("reply"),
+                "emotion": persona_result.get("emotion"),
+                "reasoning": reasoning.get("thought"),
+            },
+        )
+
+        voice_url = await _synthesize_voice(client, persona_result.get("reply", ""), persona_result.get("emotion"))
+
+        return ConversationResponse(
+            persona_response=ConversationTurn(
+                text=persona_result.get("reply", ""),
+                voice_url=voice_url,
+                emotion=persona_result.get("emotion"),
+            ),
+            reasoning=reasoning.get("thought", ""),
+            memory_reference=memory_id,
+        )

--- a/odysseia/mentis/requirements.txt
+++ b/odysseia/mentis/requirements.txt
@@ -1,2 +1,3 @@
 fastapi
 uvicorn[standard]
+httpx


### PR DESCRIPTION
## Summary
- map the PRD layers to concrete services in the agent manager and expose orchestrated conversation, task execution, and opportunity APIs
- replace the mentis conversation handler with ElevenLabs voice I/O, Inworld persona routing, Gemini 3 reasoning, and Reveta persistence
- refactor chronos to plan with Gemini 3, dispatch execution to Sesame, store outcomes in Reveta, and add opportunity flow support while updating dependencies

## Testing
- python -m compileall odysseia/agent_manager odysseia/mentis odysseia/chronos

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ccf1515fc832c8d1fcddc3d890152)