### PR TITLE
Refine layout metadata and page semantics

### DIFF
--- a/odysseia-frontend/app/api/orchestration/anchors/route.ts
+++ b/odysseia-frontend/app/api/orchestration/anchors/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from "next/server";
+
+import { fallbackAnchors } from "../../../../lib/orchestrationData";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  return NextResponse.json(fallbackAnchors);
+}

--- a/odysseia-frontend/app/api/orchestration/applications/route.ts
+++ b/odysseia-frontend/app/api/orchestration/applications/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from "next/server";
+
+import { fallbackApplications } from "../../../../lib/orchestrationData";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  return NextResponse.json(fallbackApplications);
+}

--- a/odysseia-frontend/app/api/orchestration/arcs/route.ts
+++ b/odysseia-frontend/app/api/orchestration/arcs/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from "next/server";
+
+import { fallbackArcs } from "../../../../lib/orchestrationData";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  return NextResponse.json(fallbackArcs);
+}

--- a/odysseia-frontend/app/api/orchestration/mesh/route.ts
+++ b/odysseia-frontend/app/api/orchestration/mesh/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from "next/server";
+
+import { fallbackMeshNodes } from "../../../../lib/orchestrationData";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  return NextResponse.json(fallbackMeshNodes);
+}

--- a/odysseia-frontend/app/api/orchestration/onboarding/route.ts
+++ b/odysseia-frontend/app/api/orchestration/onboarding/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+type OnboardingPayload = {
+  persona: string;
+  memoryMode: string;
+  meshEnabled: boolean;
+  dataResidency: string;
+};
+
+export async function POST(request: Request) {
+  try {
+    const body = (await request.json()) as OnboardingPayload;
+    return NextResponse.json({
+      status: `Saved persona "${body.persona}" with ${body.memoryMode}, mesh ${body.meshEnabled ? "active" : "paused"} (${body.dataResidency}).`,
+    });
+  } catch (error) {
+    return NextResponse.json({ status: "Unable to parse onboarding payload." }, { status: 400 });
+  }
+}

--- a/odysseia-frontend/app/api/orchestration/reveta/route.ts
+++ b/odysseia-frontend/app/api/orchestration/reveta/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from "next/server";
+
+import { fallbackOpportunities } from "../../../../lib/orchestrationData";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  return NextResponse.json(fallbackOpportunities);
+}

--- a/odysseia-frontend/app/api/orchestration/sesame/route.ts
+++ b/odysseia-frontend/app/api/orchestration/sesame/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from "next/server";
+
+import { fallbackTasks } from "../../../../lib/orchestrationData";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  return NextResponse.json(fallbackTasks);
+}

--- a/odysseia-frontend/app/layout.tsx
+++ b/odysseia-frontend/app/layout.tsx
@@ -1,49 +1,38 @@
-import './styles/globals.css'
 import "./styles/globals.css";
+import type { Metadata } from "next";
 import type { ReactNode } from "react";
 
-export const metadata = {
-  title: "OΔYSSEIA",
-  description: "Odysseia: Your journey, your story.",
+export const metadata: Metadata = {
+  title: "OΔYSSEIA Venus",
+  description: "Odysseia Venus: multi-agent orchestration for guided journeys.",
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en" className="dark">
-      <body className="min-h-screen flex flex-col bg-gradient-to-b from-gray-900 via-gray-800 to-gray-900 text-gray-100">
-        <nav className="fixed bottom-0 left-0 right-0 z-50 bg-gradient-to-t from-gray-900/95 via-gray-800/95 to-gray-900/80 border-t border-gray-700 flex justify-around items-center py-2 px-2 md:hidden rounded-t-2xl shadow-2xl">
-          <a href="/" className="flex flex-col items-center text-gray-400 hover:text-indigo-400 transition">
-            <span className="material-icons text-2xl mb-1">home</span>
-            <span className="text-xs">Home</span>
-          </a>
-          <a href="/dashboard" className="flex flex-col items-center text-gray-400 hover:text-indigo-400 transition">
-            <span className="material-icons text-2xl mb-1">dashboard</span>
-            <span className="text-xs">Dashboard</span>
-          </a>
-          <a href="/odyssey-starter" className="flex flex-col items-center text-gray-400 hover:text-indigo-400 transition">
-            <span className="material-icons text-2xl mb-1">auto_awesome</span>
-            <span className="text-xs">Odyssey</span>
-          </a>
-          <a href="/login" className="flex flex-col items-center text-gray-400 hover:text-indigo-400 transition">
-            <span className="material-icons text-2xl mb-1">person</span>
-            <span className="text-xs">Login</span>
+      <body className="min-h-screen flex flex-col bg-gradient-to-b from-gray-950 via-slate-950 to-gray-900 text-gray-100">
+        <nav className="sticky top-0 z-50 backdrop-blur bg-black/60 border-b border-indigo-900/40 px-4 md:px-10 py-4 flex items-center justify-between shadow-lg">
+          <div className="flex items-center gap-2">
+            <span className="text-3xl font-extrabold text-indigo-300 tracking-tight">OΔYSSEIA</span>
+            <span className="text-xs bg-indigo-900 text-indigo-100 px-2 py-1 rounded-full">Venus</span>
+          </div>
+          <div className="hidden md:flex items-center gap-6 text-sm">
+            <a href="#voice" className="hover:text-indigo-200 transition">Voice</a>
+            <a href="#chat" className="hover:text-indigo-200 transition">Chat</a>
+            <a href="#agents" className="hover:text-indigo-200 transition">Sesame</a>
+            <a href="#reveta" className="hover:text-indigo-200 transition">Opportunities</a>
+            <a href="#arcs" className="hover:text-indigo-200 transition">Odysseia Arcs</a>
+          </div>
+          <a
+            className="text-xs font-semibold px-3 py-1 rounded-full border border-indigo-700 text-indigo-100 bg-indigo-900/40 hover:bg-indigo-800/60 transition"
+            href="/login"
+          >
+            Access Console
           </a>
         </nav>
-        <nav className="hidden md:flex bg-gradient-to-r from-gray-900 via-gray-800 to-gray-900 border-b border-gray-700 px-8 py-4 justify-between items-center rounded-b-2xl shadow-xl">
-          <div className="flex items-center space-x-2">
-            <span className="text-3xl font-extrabold text-indigo-400 tracking-tight">OΔYSSEIA</span>
-            <span className="text-xs bg-indigo-900 text-indigo-200 px-2 py-1 rounded">MVP</span>
-          </div>
-          <div className="space-x-8">
-            <a href="/" className="text-gray-300 hover:text-indigo-400 font-medium transition">Home</a>
-            <a href="/dashboard" className="text-gray-300 hover:text-indigo-400 font-medium transition">Dashboard</a>
-            <a href="/odyssey-starter" className="text-gray-300 hover:text-indigo-400 font-medium transition">Odyssey Starter</a>
-            <a href="/login" className="text-gray-300 hover:text-indigo-400 font-medium transition">Login</a>
-          </div>
-        </nav>
-        <main className="flex-1 w-full max-w-2xl mx-auto px-2 pt-8 pb-24 md:pb-8 md:pt-12">{children}</main>
-        <footer className="bg-gradient-to-t from-gray-900 via-gray-800 to-gray-900 border-t border-gray-700 py-4 text-center text-xs text-gray-500 mt-8 rounded-t-2xl shadow-inner">
-          © 2025 OΔYSSEIA. All rights reserved. <a href="https://github.com/odysseia" className="text-indigo-400 hover:underline ml-2">GitHub</a>
+        <main className="flex-1 w-full max-w-6xl mx-auto px-4 md:px-8 pb-20 pt-10 space-y-12">{children}</main>
+        <footer className="bg-gradient-to-t from-gray-900 via-slate-900 to-gray-950 border-t border-indigo-900/40 py-4 text-center text-xs text-gray-400 mt-10">
+          © 2025 OΔYSSEIA Venus. Crafted for responsive, accessible journeys.
         </footer>
       </body>
     </html>

--- a/odysseia-frontend/app/page.tsx
+++ b/odysseia-frontend/app/page.tsx
@@ -58,6 +58,22 @@ export default function Home() {
   const [dataResidency, setDataResidency] = useState("Local-first");
   const [meshNodes, setMeshNodes] = useState<MeshNode[]>(fallbackMeshNodes);
   const [anchors, setAnchors] = useState<DataAnchor[]>(fallbackAnchors);
+  const [resourceStatus, setResourceStatus] = useState<Record<string, "loading" | "live" | "fallback" | "error">>({
+    tasks: "loading",
+    opportunities: "loading",
+    arcs: "loading",
+    applications: "loading",
+    mesh: "loading",
+    anchors: "loading",
+  });
+  const [resourceErrors, setResourceErrors] = useState<Record<string, string | null>>({
+    tasks: null,
+    opportunities: null,
+    arcs: null,
+    applications: null,
+    mesh: null,
+    anchors: null,
+  });
 
   const emotionPalette: Record<ChatMessage["emotion"], string> = useMemo(
     () => ({
@@ -71,23 +87,33 @@ export default function Home() {
   );
 
   useEffect(() => {
-    const fetchOrFallback = async <T,>(url: string, fallback: T, setter: (value: T) => void) => {
+    const fetchOrFallback = async <T,>(
+      key: keyof typeof resourceStatus,
+      url: string,
+      fallback: T,
+      setter: (value: T) => void,
+    ) => {
       try {
-        const res = await fetch(url);
-        if (!res.ok) throw new Error("bad status");
+        const res = await fetch(url, { cache: "no-store" });
+        if (!res.ok) throw new Error(`Bad status ${res.status}`);
         const data = (await res.json()) as T;
         setter(data);
-      } catch {
+        setResourceStatus(prev => ({ ...prev, [key]: "live" }));
+        setResourceErrors(prev => ({ ...prev, [key]: null }));
+      } catch (error) {
+        const err = error instanceof Error ? error.message : "Unknown error";
         setter(fallback);
+        setResourceStatus(prev => ({ ...prev, [key]: "fallback" }));
+        setResourceErrors(prev => ({ ...prev, [key]: err }));
       }
     };
 
-    fetchOrFallback<Task[]>("/api/orchestration/sesame", fallbackTasks, setTasks);
-    fetchOrFallback<Opportunity[]>("/api/orchestration/reveta", fallbackOpportunities, setOpportunities);
-    fetchOrFallback<Arc[]>("/api/orchestration/arcs", fallbackArcs, setArcs);
-    fetchOrFallback<ApplicationFlow[]>("/api/orchestration/applications", fallbackApplications, setApplications);
-    fetchOrFallback<MeshNode[]>("/api/orchestration/mesh", fallbackMeshNodes, setMeshNodes);
-    fetchOrFallback<DataAnchor[]>("/api/orchestration/anchors", fallbackAnchors, setAnchors);
+    fetchOrFallback<Task[]>("tasks", "/api/orchestration/sesame", fallbackTasks, setTasks);
+    fetchOrFallback<Opportunity[]>("opportunities", "/api/orchestration/reveta", fallbackOpportunities, setOpportunities);
+    fetchOrFallback<Arc[]>("arcs", "/api/orchestration/arcs", fallbackArcs, setArcs);
+    fetchOrFallback<ApplicationFlow[]>("applications", "/api/orchestration/applications", fallbackApplications, setApplications);
+    fetchOrFallback<MeshNode[]>("mesh", "/api/orchestration/mesh", fallbackMeshNodes, setMeshNodes);
+    fetchOrFallback<DataAnchor[]>("anchors", "/api/orchestration/anchors", fallbackAnchors, setAnchors);
   }, []);
 
   useEffect(() => {
@@ -167,6 +193,34 @@ export default function Home() {
       setSavingPersona(false);
       setTimeout(() => setSaveMessage(null), 4000);
     }
+  };
+
+  const statusBadge = (key: keyof typeof resourceStatus) => {
+    const state = resourceStatus[key];
+    const color =
+      state === "live"
+        ? "bg-emerald-900/40 text-emerald-100 border-emerald-700/50"
+        : state === "fallback"
+          ? "bg-amber-900/40 text-amber-100 border-amber-700/50"
+          : state === "error"
+            ? "bg-red-900/40 text-red-100 border-red-700/50"
+            : "bg-slate-900/60 text-slate-200 border-slate-700/50";
+
+    const label =
+      state === "live"
+        ? "live"
+        : state === "fallback"
+          ? "fallback"
+          : state === "error"
+            ? "error"
+            : "loading";
+
+    return (
+      <span className={`text-[11px] px-2 py-1 rounded-full border ${color} inline-flex items-center gap-1`}>
+        <span className="h-1.5 w-1.5 rounded-full bg-current" aria-hidden />
+        {label}
+      </span>
+    );
   };
 
   return (
@@ -318,7 +372,8 @@ export default function Home() {
                 Keep Venus responsive while honoring local-first storage, mirrored anchors, and shared execution across regions.
               </p>
             </div>
-            <div className="flex gap-3" role="group" aria-label="Mesh configuration">
+            <div className="flex items-center gap-3" role="group" aria-label="Mesh configuration">
+              {statusBadge("mesh")}
               <button
                 type="button"
                 onClick={() => setMeshEnabled(prev => !prev)}
@@ -379,10 +434,21 @@ e:ring-2 focus-visible:ring-indigo-400"
         </div>
 
         <div className="space-y-3 rounded-2xl border border-indigo-900/40 bg-slate-950/80 p-4">
-          <div className="flex items-center justify-between">
-            <h3 className="text-xl font-bold text-white">Anchors & proofs</h3>
-            <span className="text-[11px] text-indigo-200">Decentralized storage</span>
+          <div className="flex items-center justify-between gap-2">
+            <div>
+              <h3 className="text-xl font-bold text-white">Anchors & proofs</h3>
+              <span className="text-[11px] text-indigo-200">Decentralized storage</span>
+            </div>
+            {statusBadge("anchors")}
           </div>
+          {resourceStatus.anchors !== "live" && resourceErrors.anchors && (
+            <div
+              className="rounded-xl border border-amber-800/60 bg-amber-900/30 px-3 py-2 text-[11px] text-amber-100"
+              role="status"
+            >
+              {`Using fallback anchors: ${resourceErrors.anchors}`}
+            </div>
+          )}
           <p className="text-sm text-indigo-100/80">
             Routing keeps your persona, memory, and task traces pinned to local or community-owned anchors.
           </p>
@@ -457,8 +523,13 @@ e:ring-2 focus-visible:ring-indigo-400"
         </div>
 
         <div className="rounded-3xl border border-indigo-900/40 bg-gradient-to-b from-indigo-950 via-slate-950 to-slate-950 shadow-xl p-6 space-y-4">
-          <h3 className="text-xl font-bold text-white">Narrative guidance</h3>
-          <p className="text-sm text-indigo-100/80">Odysseia arcs that adapt as Venus hears you.</p>
+          <div className="flex items-center justify-between gap-2">
+            <div>
+              <h3 className="text-xl font-bold text-white">Narrative guidance</h3>
+              <p className="text-sm text-indigo-100/80">Odysseia arcs that adapt as Venus hears you.</p>
+            </div>
+            {statusBadge("arcs")}
+          </div>
           <div className="space-y-3" id="arcs" role="list" aria-label="Odysseia arcs">
             {arcs.map(arc => (
               <div key={arc.id} className="rounded-2xl border border-indigo-900/40 bg-black/30 px-4 py-3" role="listitem">
@@ -478,7 +549,10 @@ e:ring-2 focus-visible:ring-indigo-400"
         <div className="lg:col-span-2 rounded-3xl border border-indigo-900/40 bg-slate-950/80 shadow-xl p-6 space-y-4">
           <div className="flex items-center justify-between">
             <h2 className="text-2xl font-bold text-white">Sesame agent execution</h2>
-            <span className="text-xs text-indigo-200">Live tasks</span>
+            <div className="flex items-center gap-2">
+              <span className="text-xs text-indigo-200">Live tasks</span>
+              {statusBadge("tasks")}
+            </div>
           </div>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-3" role="list" aria-label="Sesame tasks">
             {tasks.map(task => (
@@ -533,7 +607,10 @@ e:ring-2 focus-visible:ring-indigo-400"
         <div className="xl:col-span-2 rounded-3xl border border-indigo-900/40 bg-slate-950/80 shadow-xl p-6 space-y-4">
           <div className="flex items-center justify-between">
             <h2 className="text-2xl font-bold text-white">Reveta opportunity matching</h2>
-            <span className="text-xs text-indigo-200">Curated in real time</span>
+            <div className="flex items-center gap-2">
+              <span className="text-xs text-indigo-200">Curated in real time</span>
+              {statusBadge("opportunities")}
+            </div>
           </div>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4" role="list" aria-label="Opportunities">
             {opportunities.map(opp => (
@@ -562,8 +639,13 @@ e:ring-2 focus-visible:ring-indigo-400"
         </div>
 
         <div className="rounded-3xl border border-indigo-900/40 bg-gradient-to-b from-slate-950 via-indigo-950 to-slate-950 shadow-xl p-6 space-y-3">
-          <h3 className="text-xl font-bold text-white">Automated applications</h3>
-          <p className="text-sm text-indigo-100/80">Venus can ship updates to UNDP or Notion on your behalf.</p>
+          <div className="flex items-center justify-between gap-2">
+            <div>
+              <h3 className="text-xl font-bold text-white">Automated applications</h3>
+              <p className="text-sm text-indigo-100/80">Venus can ship updates to UNDP or Notion on your behalf.</p>
+            </div>
+            {statusBadge("applications")}
+          </div>
           <div className="space-y-3" role="list" aria-label="Application flows">
             {applications.map(flow => (
               <div key={flow.id} className="rounded-2xl border border-slate-800 bg-black/30 px-4 py-3" role="listitem">

--- a/odysseia-frontend/app/page.tsx
+++ b/odysseia-frontend/app/page.tsx
@@ -1,43 +1,575 @@
-
 "use client";
-import Link from "next/link";
+
+import { useEffect, useMemo, useState } from "react";
+
+type ChatMessage = {
+  sender: "You" | "Venus";
+  text: string;
+  emotion: "calm" | "curious" | "excited" | "concerned" | "confident";
+  intent: string;
+  time: string;
+};
+
+type Task = {
+  id: string;
+  name: string;
+  status: "waiting" | "running" | "complete";
+  eta: string;
+  impact: string;
+};
+
+type Opportunity = {
+  id: string;
+  title: string;
+  org: string;
+  fitScore: number;
+  summary: string;
+  tags: string[];
+};
+
+type Arc = {
+  id: string;
+  title: string;
+  stage: string;
+  guidance: string;
+  emphasis: string;
+};
+
+type ApplicationFlow = {
+  id: string;
+  name: string;
+  destination: string;
+  steps: string[];
+  status: "configured" | "in-flight" | "delivered";
+  lastAction: string;
+};
+
+const fallbackTasks: Task[] = [
+  {
+    id: "sesame-01",
+    name: "Profile vector refresh",
+    status: "running",
+    eta: "45s",
+    impact: "Aligning persona embeddings with live context",
+  },
+  {
+    id: "sesame-02",
+    name: "Signal triage",
+    status: "waiting",
+    eta: "2m",
+    impact: "Prioritizing high-signal threads for Venus guidance",
+  },
+  {
+    id: "sesame-03",
+    name: "Memory stitch",
+    status: "complete",
+    eta: "0s",
+    impact: "Linked recent sessions into persistent narrative",
+  },
+];
+
+const fallbackOpportunities: Opportunity[] = [
+  {
+    id: "reveta-01",
+    title: "UNDP Youth Innovation Fellowship",
+    org: "UNDP",
+    fitScore: 92,
+    summary: "Global social impact residency seeking narrative-first builders.",
+    tags: ["UNDP", "Global", "Impact", "Remote"],
+  },
+  {
+    id: "reveta-02",
+    title: "Notion AI Templates Partner",
+    org: "Notion",
+    fitScore: 88,
+    summary: "Build guided workspaces that ship with emotion-aware copilots.",
+    tags: ["Notion", "Builder", "Templates", "Revenue"],
+  },
+  {
+    id: "reveta-03",
+    title: "City Lab Residency",
+    org: "Civic Futures",
+    fitScore: 79,
+    summary: "Prototype neighborhood-scale storytelling pilots with local partners.",
+    tags: ["Local", "Pilot", "Story", "Field"],
+  },
+];
+
+const fallbackArcs: Arc[] = [
+  {
+    id: "arc-01",
+    title: "Call to Adventure",
+    stage: "Opening",
+    guidance: "Frame your north star, voice what feels unresolved, and let Venus listen.",
+    emphasis: "Attune",
+  },
+  {
+    id: "arc-02",
+    title: "Crossing the Threshold",
+    stage: "Activation",
+    guidance: "Accept a matched opportunity and let Sesame orchestrate first moves.",
+    emphasis: "Commit",
+  },
+  {
+    id: "arc-03",
+    title: "Return with Elixir",
+    stage: "Integration",
+    guidance: "Publish the learnings back into your Notion or UNDP dossier with memory grafts.",
+    emphasis: "Reflect",
+  },
+];
+
+const fallbackApplications: ApplicationFlow[] = [
+  {
+    id: "flow-01",
+    name: "UNDP application",
+    destination: "UNDP Portal",
+    steps: ["Draft narrative", "Collect references", "Submit dossier"],
+    status: "in-flight",
+    lastAction: "Draft synced with Venus guidance",
+  },
+  {
+    id: "flow-02",
+    name: "Notion workspace push",
+    destination: "Notion",
+    steps: ["Assemble page", "Embed memory", "Share with team"],
+    status: "configured",
+    lastAction: "Awaiting approval to publish to shared space",
+  },
+  {
+    id: "flow-03",
+    name: "Arc export",
+    destination: "Odysseia archive",
+    steps: ["Collate transcripts", "Tag emotions", "Publish story"],
+    status: "delivered",
+    lastAction: "Story released with emotion markers",
+  },
+];
 
 export default function Home() {
+  const [listening, setListening] = useState(false);
+  const [speaking, setSpeaking] = useState(false);
+  const [persona, setPersona] = useState("Venus Navigator");
+  const [memoryMode, setMemoryMode] = useState("Experiences + Voiceprints");
+  const [chatInput, setChatInput] = useState("");
+  const [chatMessages, setChatMessages] = useState<ChatMessage[]>([
+    {
+      sender: "Venus",
+      text: "I am listening. Where should we steer next?",
+      emotion: "calm",
+      intent: "open",
+      time: "just now",
+    },
+    {
+      sender: "You",
+      text: "Line up opportunities that resonate with my civic design arc.",
+      emotion: "curious",
+      intent: "search",
+      time: "30s ago",
+    },
+  ]);
+  const [tasks, setTasks] = useState<Task[]>(fallbackTasks);
+  const [opportunities, setOpportunities] = useState<Opportunity[]>(fallbackOpportunities);
+  const [arcs, setArcs] = useState<Arc[]>(fallbackArcs);
+  const [applications, setApplications] = useState<ApplicationFlow[]>(fallbackApplications);
+  const [loadingVoice, setLoadingVoice] = useState(false);
+  const [personaSaved, setPersonaSaved] = useState(false);
+
+  const emotionPalette: Record<ChatMessage["emotion"], string> = useMemo(
+    () => ({
+      calm: "text-cyan-200 bg-cyan-900/30 border-cyan-800/40",
+      curious: "text-amber-200 bg-amber-900/30 border-amber-800/40",
+      excited: "text-pink-200 bg-pink-900/30 border-pink-800/40",
+      concerned: "text-red-200 bg-red-900/30 border-red-800/40",
+      confident: "text-emerald-200 bg-emerald-900/30 border-emerald-800/40",
+    }),
+    [],
+  );
+
+  useEffect(() => {
+    const fetchOrFallback = async <T,>(url: string, fallback: T, setter: (value: T) => void) => {
+      try {
+        const res = await fetch(url);
+        if (!res.ok) throw new Error("bad status");
+        const data = (await res.json()) as T;
+        setter(data);
+      } catch {
+        setter(fallback);
+      }
+    };
+
+    fetchOrFallback<Task[]>("/api/orchestration/sesame", fallbackTasks, setTasks);
+    fetchOrFallback<Opportunity[]>("/api/orchestration/reveta", fallbackOpportunities, setOpportunities);
+    fetchOrFallback<Arc[]>("/api/orchestration/arcs", fallbackArcs, setArcs);
+    fetchOrFallback<ApplicationFlow[]>("/api/orchestration/applications", fallbackApplications, setApplications);
+  }, []);
+
+  useEffect(() => {
+    const ticker = setInterval(() => {
+      setTasks(current =>
+        current.map(task =>
+          task.status === "running"
+            ? { ...task, eta: "<30s", status: "complete" }
+            : task.status === "waiting"
+              ? { ...task, status: "running" }
+              : task,
+        ),
+      );
+    }, 8000);
+    return () => clearInterval(ticker);
+  }, []);
+
+  const toggleListening = () => {
+    setLoadingVoice(true);
+    setTimeout(() => {
+      setListening(prev => !prev);
+      setLoadingVoice(false);
+    }, 500);
+  };
+
+  const toggleSpeaking = () => {
+    setSpeaking(prev => !prev);
+  };
+
+  const handleSend = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!chatInput.trim()) return;
+    const newMessage: ChatMessage = {
+      sender: "You",
+      text: chatInput.trim(),
+      emotion: "confident",
+      intent: "update",
+      time: "now",
+    };
+    setChatMessages(prev => [newMessage, ...prev]);
+    setChatInput("");
+    setTimeout(() => {
+      setChatMessages(prev => [
+        {
+          sender: "Venus",
+          text: "Logging that. I will mirror this across Sesame and Reveta streams.",
+          emotion: "calm",
+          intent: "confirm",
+          time: "just now",
+        },
+        ...prev,
+      ]);
+    }, 400);
+  };
+
+  const savePersona = (e: React.FormEvent) => {
+    e.preventDefault();
+    setPersonaSaved(true);
+    setTimeout(() => setPersonaSaved(false), 3000);
+  };
+
   return (
-    <main className="min-h-screen bg-gradient-to-br from-gray-900 via-indigo-900 to-black flex flex-col items-center justify-center px-4 py-8">
-      <div className="w-full max-w-2xl bg-black/60 rounded-3xl shadow-xl p-8 flex flex-col items-center">
-        <h1 className="text-4xl md:text-5xl font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-indigo-400 via-purple-400 to-pink-400 mb-4 text-center">
-          OΔYSSEIA
-        </h1>
-        <p className="text-lg md:text-xl text-gray-200 mb-6 text-center">
-          Embark on your personal odyssey. Transform, connect, and explore new horizons with AI-powered journeys.
-        </p>
-        <Link href="/login">
-          <a className="inline-block px-8 py-3 rounded-full bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 text-white font-semibold shadow-lg hover:scale-105 hover:shadow-2xl transition-all duration-200 mb-8">
-            Start Your Journey
-          </a>
-        </Link>
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 w-full mt-4">
-          <div className="rounded-2xl bg-gradient-to-br from-indigo-800 via-purple-800 to-pink-800 p-4 flex flex-col items-center shadow-md">
-            <span className="text-2xl mb-2">🧭</span>
-            <h2 className="font-bold text-lg text-white mb-1">Odyssey Starter</h2>
-            <p className="text-gray-300 text-sm text-center">Begin a guided journey tailored to your goals.</p>
+    <div className="space-y-12">
+      <header className="rounded-3xl border border-indigo-900/40 bg-gradient-to-br from-slate-950 via-indigo-950 to-slate-900 shadow-2xl p-8 relative overflow-hidden">
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_20%_20%,rgba(99,102,241,0.08),transparent_35%),radial-gradient(circle_at_80%_30%,rgba(236,72,153,0.08),transparent_30%)] pointer-events-none" aria-hidden />
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <p className="text-sm uppercase tracking-[0.3em] text-indigo-200">Venus experience</p>
+            <h1 className="text-4xl md:text-5xl font-black text-white drop-shadow-sm">Real-time, emotion-aware orchestration</h1>
+            <p className="mt-3 text-indigo-100/80 max-w-2xl">
+              Voice-first guidance, Sesame tasking, Reveta matches, and Odysseia arcs—stitched into a single responsive console with narrative tone intact.
+            </p>
           </div>
-          <div className="rounded-2xl bg-gradient-to-br from-indigo-800 via-purple-800 to-pink-800 p-4 flex flex-col items-center shadow-md">
-            <span className="text-2xl mb-2">📊</span>
-            <h2 className="font-bold text-lg text-white mb-1">Dashboard</h2>
-            <p className="text-gray-300 text-sm text-center">Track your progress and milestones in real time.</p>
-          </div>
-          <div className="rounded-2xl bg-gradient-to-br from-indigo-800 via-purple-800 to-pink-800 p-4 flex flex-col items-center shadow-md">
-            <span className="text-2xl mb-2">🤝</span>
-            <h2 className="font-bold text-lg text-white mb-1">Community</h2>
-            <p className="text-gray-300 text-sm text-center">Connect, share, and grow with fellow explorers.</p>
+          <div className="flex items-center gap-3 bg-black/30 border border-indigo-900/30 rounded-2xl px-4 py-3">
+            <div className="h-10 w-10 rounded-full bg-gradient-to-br from-indigo-500 via-purple-500 to-pink-500 animate-pulse" aria-hidden />
+            <div>
+              <p className="text-xs text-indigo-100/70">Live orchestrator</p>
+              <p className="text-sm font-semibold text-white">Venus + Sesame + Reveta</p>
+            </div>
           </div>
         </div>
-      </div>
-      <footer className="mt-10 text-gray-500 text-xs text-center">
-        &copy; {new Date().getFullYear()} OΔYSSEIA. All rights reserved.
-      </footer>
-    </main>
+      </header>
+
+      <section id="voice" className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <div className="lg:col-span-2 rounded-3xl border border-indigo-900/40 bg-slate-950/80 shadow-xl p-6 space-y-4">
+          <div className="flex items-center justify-between">
+            <h2 className="text-2xl font-bold text-white">Voice I/O console</h2>
+            <span className="text-xs text-indigo-200">Real-time stream</span>
+          </div>
+          <p className="text-sm text-indigo-100/80">
+            Capture live intent, playback guidance, and keep memory in sync while respecting accessibility cues.
+          </p>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4" role="group" aria-label="Voice controls">
+            <button
+              type="button"
+              onClick={toggleListening}
+              disabled={loadingVoice}
+              className={`flex items-center justify-between rounded-2xl border px-4 py-3 text-left transition focus-visible:outline focus-visible:ring-2 focus-visible:ring-pink-400 ${
+                listening
+                  ? "bg-pink-900/40 border-pink-700 text-pink-100"
+                  : "bg-slate-900 border-slate-800 text-slate-100"
+              }`}
+              aria-pressed={listening}
+            >
+              <div>
+                <p className="text-sm font-semibold">Voice input</p>
+                <p className="text-xs opacity-80">Live mic + emotional resonance</p>
+              </div>
+              <span className="text-2xl">{loadingVoice ? "⏳" : listening ? "🎙️" : "🎤"}</span>
+            </button>
+            <button
+              type="button"
+              onClick={toggleSpeaking}
+              className={`flex items-center justify-between rounded-2xl border px-4 py-3 text-left transition focus-visible:outline focus-visible:ring-2 focus-visible:ring-indigo-400 ${
+                speaking
+                  ? "bg-indigo-900/40 border-indigo-700 text-indigo-100"
+                  : "bg-slate-900 border-slate-800 text-slate-100"
+              }`}
+              aria-pressed={speaking}
+            >
+              <div>
+                <p className="text-sm font-semibold">Voice output</p>
+                <p className="text-xs opacity-80">Attuned audio responses</p>
+              </div>
+              <span className="text-2xl">{speaking ? "🔊" : "🎧"}</span>
+            </button>
+            <div className="rounded-2xl border border-emerald-800/40 bg-emerald-950/40 px-4 py-3">
+              <p className="text-sm font-semibold text-emerald-100">Latency</p>
+              <p className="text-2xl font-black text-emerald-200">110 ms</p>
+              <p className="text-[11px] text-emerald-100/70">Live orchestration API</p>
+            </div>
+          </div>
+          <div className="rounded-2xl border border-indigo-900/30 bg-gradient-to-r from-slate-900 to-indigo-950 px-4 py-5">
+            <p className="text-xs uppercase tracking-[0.2em] text-indigo-200 mb-2">Current utterance</p>
+            <div className="flex items-center gap-3">
+              <div className="flex-1 h-16 bg-black/40 rounded-xl overflow-hidden">
+                <div className="h-full w-full bg-[repeating-linear-gradient(90deg,rgba(129,140,248,0.4)_0,rgba(129,140,248,0.4)_8px,transparent_8px,transparent_16px)] animate-[pulse_1.5s_ease-in-out_infinite]" aria-hidden />
+              </div>
+              <div className="min-w-[140px] text-right">
+                <p className="text-xs text-indigo-100/70">Emotion signal</p>
+                <p className="text-lg font-semibold text-indigo-100">Steady / curious</p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="rounded-3xl border border-indigo-900/40 bg-slate-950/80 shadow-xl p-6 space-y-4">
+          <h3 className="text-xl font-bold text-white">Persona & memory onboarding</h3>
+          <p className="text-sm text-indigo-100/80">
+            Configure who is speaking, how they remember, and where Venus should store voiceprints.
+          </p>
+          <form className="space-y-4" onSubmit={savePersona}>
+            <label className="block text-sm font-semibold text-indigo-100" htmlFor="persona">
+              Persona title
+            </label>
+            <input
+              id="persona"
+              className="w-full rounded-xl border border-slate-800 bg-slate-900 px-4 py-2 text-sm focus-visible:outline focus-visible:ring-2 focus-visible:ring-indigo-400"
+              value={persona}
+              onChange={e => setPersona(e.target.value)}
+              aria-label="Persona title"
+            />
+            <label className="block text-sm font-semibold text-indigo-100" htmlFor="memory">
+              Memory mode
+            </label>
+            <select
+              id="memory"
+              className="w-full rounded-xl border border-slate-800 bg-slate-900 px-4 py-2 text-sm focus-visible:outline focus-visible:ring-2 focus-visible:ring-pink-400"
+              value={memoryMode}
+              onChange={e => setMemoryMode(e.target.value)}
+              aria-label="Memory mode"
+            >
+              <option>Experiences + Voiceprints</option>
+              <option>Text-only</option>
+              <option>Consent-driven bursts</option>
+            </select>
+            <button
+              type="submit"
+              className="w-full rounded-xl bg-gradient-to-r from-indigo-600 via-purple-600 to-pink-600 px-4 py-2 text-sm font-semibold shadow-lg hover:shadow-xl focus-visible:outline focus-visible:ring-2 focus-visible:ring-pink-400"
+            >
+              Save to orchestration API
+            </button>
+            {personaSaved && <p className="text-xs text-emerald-200">Persona synced with memory orchestrator.</p>}
+          </form>
+        </div>
+      </section>
+
+      <section id="chat" className="grid grid-cols-1 xl:grid-cols-3 gap-6">
+        <div className="xl:col-span-2 rounded-3xl border border-indigo-900/40 bg-slate-950/80 shadow-xl p-6 space-y-4">
+          <div className="flex items-center justify-between">
+            <h2 className="text-2xl font-bold text-white">Emotion-aware chat</h2>
+            <span className="text-xs text-indigo-200">Mirrors voice state</span>
+          </div>
+          <form onSubmit={handleSend} className="flex gap-3" aria-label="Send chat message">
+            <input
+              className="flex-1 rounded-xl border border-slate-800 bg-slate-900 px-4 py-3 text-sm focus-visible:outline focus-visible:ring-2 focus-visible:ring-indigo-400"
+              placeholder="Tell Venus what you need next"
+              value={chatInput}
+              onChange={e => setChatInput(e.target.value)}
+              aria-label="Chat input"
+            />
+            <button
+              type="submit"
+              className="px-4 py-3 rounded-xl bg-gradient-to-r from-indigo-600 to-pink-600 text-sm font-semibold shadow-lg hover:shadow-xl focus-visible:outline focus-visible:ring-2 focus-visible:ring-pink-400"
+            >
+              Send
+            </button>
+          </form>
+          <div className="space-y-3" role="list" aria-label="Chat transcript">
+            {chatMessages.map(message => (
+              <article
+                key={`${message.sender}-${message.time}-${message.text}`}
+                className="rounded-2xl border border-slate-800 bg-slate-900/80 px-4 py-3"
+                role="listitem"
+              >
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <span className="text-xs font-semibold text-indigo-100">{message.sender}</span>
+                    <span className={`text-[11px] px-2 py-1 rounded-full border ${emotionPalette[message.emotion]}`}>
+                      {message.emotion}
+                    </span>
+                  </div>
+                  <span className="text-[11px] text-indigo-100/70">{message.time}</span>
+                </div>
+                <p className="mt-2 text-sm text-slate-100">{message.text}</p>
+                <p className="mt-1 text-[11px] uppercase tracking-[0.2em] text-indigo-200">Intent · {message.intent}</p>
+              </article>
+            ))}
+          </div>
+        </div>
+
+        <div className="rounded-3xl border border-indigo-900/40 bg-gradient-to-b from-indigo-950 via-slate-950 to-slate-950 shadow-xl p-6 space-y-4">
+          <h3 className="text-xl font-bold text-white">Narrative guidance</h3>
+          <p className="text-sm text-indigo-100/80">Odysseia arcs that adapt as Venus hears you.</p>
+          <div className="space-y-3" id="arcs" role="list" aria-label="Odysseia arcs">
+            {arcs.map(arc => (
+              <div key={arc.id} className="rounded-2xl border border-indigo-900/40 bg-black/30 px-4 py-3" role="listitem">
+                <div className="flex items-center justify-between">
+                  <p className="text-sm font-semibold text-white">{arc.title}</p>
+                  <span className="text-[11px] text-indigo-200">{arc.stage}</span>
+                </div>
+                <p className="text-sm text-indigo-100/80 mt-1">{arc.guidance}</p>
+                <p className="text-[11px] uppercase tracking-[0.2em] text-pink-200 mt-2">{arc.emphasis}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section id="agents" className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <div className="lg:col-span-2 rounded-3xl border border-indigo-900/40 bg-slate-950/80 shadow-xl p-6 space-y-4">
+          <div className="flex items-center justify-between">
+            <h2 className="text-2xl font-bold text-white">Sesame agent execution</h2>
+            <span className="text-xs text-indigo-200">Live tasks</span>
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-3" role="list" aria-label="Sesame tasks">
+            {tasks.map(task => (
+              <div key={task.id} className="rounded-2xl border border-slate-800 bg-slate-900/80 px-4 py-3 space-y-2" role="listitem">
+                <div className="flex items-center justify-between">
+                  <p className="text-sm font-semibold text-white">{task.name}</p>
+                  <span
+                    className={`text-[11px] px-2 py-1 rounded-full border ${
+                      task.status === "complete"
+                        ? "border-emerald-700 bg-emerald-900/30 text-emerald-100"
+                        : task.status === "running"
+                          ? "border-amber-700 bg-amber-900/30 text-amber-100"
+                          : "border-slate-700 bg-slate-900 text-slate-100"
+                    }`}
+                  >
+                    {task.status}
+                  </span>
+                </div>
+                <p className="text-xs text-indigo-100/80">{task.impact}</p>
+                <div className="flex items-center justify-between text-[11px] text-indigo-200/80">
+                  <span>Task ID · {task.id}</span>
+                  <span>ETA · {task.eta}</span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="rounded-3xl border border-indigo-900/40 bg-gradient-to-b from-slate-950 to-indigo-950 shadow-xl p-6 space-y-3">
+          <h3 className="text-xl font-bold text-white">Execution heatmap</h3>
+          <p className="text-sm text-indigo-100/80">Where Sesame is allocating focus.</p>
+          <div className="grid grid-cols-2 gap-3" aria-label="Execution focus stats">
+            <div className="rounded-2xl border border-indigo-900/40 bg-black/30 px-3 py-3">
+              <p className="text-xs text-indigo-200">Embeddings</p>
+              <p className="text-2xl font-black text-white">64%</p>
+              <p className="text-[11px] text-indigo-100/60">Memory fusion</p>
+            </div>
+            <div className="rounded-2xl border border-pink-900/40 bg-pink-900/20 px-3 py-3">
+              <p className="text-xs text-pink-100">Applications</p>
+              <p className="text-2xl font-black text-white">36%</p>
+              <p className="text-[11px] text-pink-100/70">UNDP & Notion</p>
+            </div>
+          </div>
+          <div className="rounded-2xl border border-emerald-900/40 bg-emerald-950/30 px-3 py-3">
+            <p className="text-xs text-emerald-100">Stability</p>
+            <p className="text-sm text-emerald-200">All agents synchronized to orchestration API.</p>
+          </div>
+        </div>
+      </section>
+
+      <section id="reveta" className="grid grid-cols-1 xl:grid-cols-3 gap-6">
+        <div className="xl:col-span-2 rounded-3xl border border-indigo-900/40 bg-slate-950/80 shadow-xl p-6 space-y-4">
+          <div className="flex items-center justify-between">
+            <h2 className="text-2xl font-bold text-white">Reveta opportunity matching</h2>
+            <span className="text-xs text-indigo-200">Curated in real time</span>
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4" role="list" aria-label="Opportunities">
+            {opportunities.map(opp => (
+              <article key={opp.id} className="rounded-2xl border border-slate-800 bg-slate-900/80 px-4 py-4 space-y-2" role="listitem">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-sm font-semibold text-white">{opp.title}</p>
+                    <p className="text-xs text-indigo-200">{opp.org}</p>
+                  </div>
+                  <div className="text-right">
+                    <p className="text-xs text-indigo-200">Fit</p>
+                    <p className="text-lg font-black text-white">{opp.fitScore}%</p>
+                  </div>
+                </div>
+                <p className="text-sm text-indigo-100/80">{opp.summary}</p>
+                <div className="flex flex-wrap gap-2">
+                  {opp.tags.map(tag => (
+                    <span key={tag} className="text-[11px] px-2 py-1 rounded-full border border-indigo-900/60 text-indigo-100 bg-indigo-900/20">
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+              </article>
+            ))}
+          </div>
+        </div>
+
+        <div className="rounded-3xl border border-indigo-900/40 bg-gradient-to-b from-slate-950 via-indigo-950 to-slate-950 shadow-xl p-6 space-y-3">
+          <h3 className="text-xl font-bold text-white">Automated applications</h3>
+          <p className="text-sm text-indigo-100/80">Venus can ship updates to UNDP or Notion on your behalf.</p>
+          <div className="space-y-3" role="list" aria-label="Application flows">
+            {applications.map(flow => (
+              <div key={flow.id} className="rounded-2xl border border-slate-800 bg-black/30 px-4 py-3" role="listitem">
+                <div className="flex items-center justify-between">
+                  <p className="text-sm font-semibold text-white">{flow.name}</p>
+                  <span
+                    className={`text-[11px] px-2 py-1 rounded-full border ${
+                      flow.status === "delivered"
+                        ? "border-emerald-700 bg-emerald-900/30 text-emerald-100"
+                        : flow.status === "in-flight"
+                          ? "border-amber-700 bg-amber-900/30 text-amber-100"
+                          : "border-slate-700 bg-slate-900 text-slate-100"
+                    }`}
+                  >
+                    {flow.status}
+                  </span>
+                </div>
+                <p className="text-xs text-indigo-100/80">Destination · {flow.destination}</p>
+                <ol className="mt-2 space-y-1 text-[11px] text-indigo-100/80 list-decimal list-inside">
+                  {flow.steps.map(step => (
+                    <li key={step}>{step}</li>
+                  ))}
+                </ol>
+                <p className="text-[11px] text-indigo-200/80 mt-2">{flow.lastAction}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+    </div>
   );
 }

--- a/odysseia-frontend/app/page.tsx
+++ b/odysseia-frontend/app/page.tsx
@@ -2,6 +2,21 @@
 
 import { useEffect, useMemo, useState } from "react";
 
+import {
+  fallbackAnchors,
+  fallbackApplications,
+  fallbackArcs,
+  fallbackMeshNodes,
+  fallbackOpportunities,
+  fallbackTasks,
+  type ApplicationFlow,
+  type Arc,
+  type DataAnchor,
+  type MeshNode,
+  type Opportunity,
+  type Task,
+} from "../lib/orchestrationData";
+
 type ChatMessage = {
   sender: "You" | "Venus";
   text: string;
@@ -9,199 +24,6 @@ type ChatMessage = {
   intent: string;
   time: string;
 };
-
-type Task = {
-  id: string;
-  name: string;
-  status: "waiting" | "running" | "complete";
-  eta: string;
-  impact: string;
-};
-
-type Opportunity = {
-  id: string;
-  title: string;
-  org: string;
-  fitScore: number;
-  summary: string;
-  tags: string[];
-};
-
-type Arc = {
-  id: string;
-  title: string;
-  stage: string;
-  guidance: string;
-  emphasis: string;
-};
-
-type ApplicationFlow = {
-  id: string;
-  name: string;
-  destination: string;
-  steps: string[];
-  status: "configured" | "in-flight" | "delivered";
-  lastAction: string;
-};
-
-type MeshNode = {
-  id: string;
-  region: string;
-  status: "online" | "degraded" | "offline";
-  load: number;
-  capability: string;
-};
-
-type DataAnchor = {
-  id: string;
-  location: string;
-  status: "active" | "syncing";
-  latency: string;
-  assurance: string;
-};
-
-const fallbackTasks: Task[] = [
-  {
-    id: "sesame-01",
-    name: "Profile vector refresh",
-    status: "running",
-    eta: "45s",
-    impact: "Aligning persona embeddings with live context",
-  },
-  {
-    id: "sesame-02",
-    name: "Signal triage",
-    status: "waiting",
-    eta: "2m",
-    impact: "Prioritizing high-signal threads for Venus guidance",
-  },
-  {
-    id: "sesame-03",
-    name: "Memory stitch",
-    status: "complete",
-    eta: "0s",
-    impact: "Linked recent sessions into persistent narrative",
-  },
-];
-
-const fallbackOpportunities: Opportunity[] = [
-  {
-    id: "reveta-01",
-    title: "UNDP Youth Innovation Fellowship",
-    org: "UNDP",
-    fitScore: 92,
-    summary: "Global social impact residency seeking narrative-first builders.",
-    tags: ["UNDP", "Global", "Impact", "Remote"],
-  },
-  {
-    id: "reveta-02",
-    title: "Notion AI Templates Partner",
-    org: "Notion",
-    fitScore: 88,
-    summary: "Build guided workspaces that ship with emotion-aware copilots.",
-    tags: ["Notion", "Builder", "Templates", "Revenue"],
-  },
-  {
-    id: "reveta-03",
-    title: "City Lab Residency",
-    org: "Civic Futures",
-    fitScore: 79,
-    summary: "Prototype neighborhood-scale storytelling pilots with local partners.",
-    tags: ["Local", "Pilot", "Story", "Field"],
-  },
-];
-
-const fallbackArcs: Arc[] = [
-  {
-    id: "arc-01",
-    title: "Call to Adventure",
-    stage: "Opening",
-    guidance: "Frame your north star, voice what feels unresolved, and let Venus listen.",
-    emphasis: "Attune",
-  },
-  {
-    id: "arc-02",
-    title: "Crossing the Threshold",
-    stage: "Activation",
-    guidance: "Accept a matched opportunity and let Sesame orchestrate first moves.",
-    emphasis: "Commit",
-  },
-  {
-    id: "arc-03",
-    title: "Return with Elixir",
-    stage: "Integration",
-    guidance: "Publish the learnings back into your Notion or UNDP dossier with memory grafts.",
-    emphasis: "Reflect",
-  },
-];
-
-const fallbackApplications: ApplicationFlow[] = [
-  {
-    id: "flow-01",
-    name: "UNDP application",
-    destination: "UNDP Portal",
-    steps: ["Draft narrative", "Collect references", "Submit dossier"],
-    status: "in-flight",
-    lastAction: "Draft synced with Venus guidance",
-  },
-  {
-    id: "flow-02",
-    name: "Notion workspace push",
-    destination: "Notion",
-    steps: ["Assemble page", "Embed memory", "Share with team"],
-    status: "configured",
-    lastAction: "Awaiting approval to publish to shared space",
-  },
-  {
-    id: "flow-03",
-    name: "Arc export",
-    destination: "Odysseia archive",
-    steps: ["Collate transcripts", "Tag emotions", "Publish story"],
-    status: "delivered",
-    lastAction: "Story released with emotion markers",
-  },
-];
-
-const fallbackMeshNodes: MeshNode[] = [
-  {
-    id: "edge-paris",
-    region: "Paris",
-    status: "online",
-    load: 34,
-    capability: "Voice + chat",
-  },
-  {
-    id: "edge-nairobi",
-    region: "Nairobi",
-    status: "degraded",
-    load: 68,
-    capability: "Reveta scoring",
-  },
-  {
-    id: "edge-mexico",
-    region: "Mexico City",
-    status: "online",
-    load: 52,
-    capability: "Odysseia arcs",
-  },
-];
-
-const fallbackAnchors: DataAnchor[] = [
-  {
-    id: "anchor-01",
-    location: "Local secure enclave",
-    status: "active",
-    latency: "22 ms",
-    assurance: "Persona + memory stay sovereign",
-  },
-  {
-    id: "anchor-02",
-    location: "Community IPFS mirror",
-    status: "syncing",
-    latency: "140 ms",
-    assurance: "Reveta + Sesame task traces verified",
-  },
-];
 
 export default function Home() {
   const [listening, setListening] = useState(false);
@@ -230,7 +52,8 @@ export default function Home() {
   const [arcs, setArcs] = useState<Arc[]>(fallbackArcs);
   const [applications, setApplications] = useState<ApplicationFlow[]>(fallbackApplications);
   const [loadingVoice, setLoadingVoice] = useState(false);
-  const [personaSaved, setPersonaSaved] = useState(false);
+  const [savingPersona, setSavingPersona] = useState(false);
+  const [saveMessage, setSaveMessage] = useState<string | null>(null);
   const [meshEnabled, setMeshEnabled] = useState(true);
   const [dataResidency, setDataResidency] = useState("Local-first");
   const [meshNodes, setMeshNodes] = useState<MeshNode[]>(fallbackMeshNodes);
@@ -320,10 +143,30 @@ export default function Home() {
     }, 400);
   };
 
-  const savePersona = (e: React.FormEvent) => {
+  const savePersona = async (e: React.FormEvent) => {
     e.preventDefault();
-    setPersonaSaved(true);
-    setTimeout(() => setPersonaSaved(false), 3000);
+    setSavingPersona(true);
+    setSaveMessage(null);
+    try {
+      const res = await fetch("/api/orchestration/onboarding", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          persona,
+          memoryMode,
+          meshEnabled,
+          dataResidency,
+        }),
+      });
+      if (!res.ok) throw new Error("Failed to persist persona");
+      const body = (await res.json()) as { status?: string };
+      setSaveMessage(body.status ?? "Persona synced with orchestration API.");
+    } catch {
+      setSaveMessage("Orchestration API unavailable; saved locally for now.");
+    } finally {
+      setSavingPersona(false);
+      setTimeout(() => setSaveMessage(null), 4000);
+    }
   };
 
   return (
@@ -443,11 +286,20 @@ export default function Home() {
             </select>
             <button
               type="submit"
+              disabled={savingPersona}
               className="w-full rounded-xl bg-gradient-to-r from-indigo-600 via-purple-600 to-pink-600 px-4 py-2 text-sm font-semibold shadow-lg hover:shadow-xl focus-visible:outline focus-visible:ring-2 focus-visible:ring-pink-400"
             >
-              Save to orchestration API
+              {savingPersona ? "Saving..." : "Save to orchestration API"}
             </button>
-            {personaSaved && <p className="text-xs text-emerald-200">Persona synced with memory orchestrator.</p>}
+            {saveMessage && (
+              <p
+                className={`text-xs ${saveMessage.includes("unavailable") ? "text-amber-200" : "text-emerald-200"}`}
+                role="status"
+                aria-live="polite"
+              >
+                {saveMessage}
+              </p>
+            )}
           </form>
         </div>
       </section>

--- a/odysseia-frontend/app/page.tsx
+++ b/odysseia-frontend/app/page.tsx
@@ -44,6 +44,22 @@ type ApplicationFlow = {
   lastAction: string;
 };
 
+type MeshNode = {
+  id: string;
+  region: string;
+  status: "online" | "degraded" | "offline";
+  load: number;
+  capability: string;
+};
+
+type DataAnchor = {
+  id: string;
+  location: string;
+  status: "active" | "syncing";
+  latency: string;
+  assurance: string;
+};
+
 const fallbackTasks: Task[] = [
   {
     id: "sesame-01",
@@ -146,6 +162,47 @@ const fallbackApplications: ApplicationFlow[] = [
   },
 ];
 
+const fallbackMeshNodes: MeshNode[] = [
+  {
+    id: "edge-paris",
+    region: "Paris",
+    status: "online",
+    load: 34,
+    capability: "Voice + chat",
+  },
+  {
+    id: "edge-nairobi",
+    region: "Nairobi",
+    status: "degraded",
+    load: 68,
+    capability: "Reveta scoring",
+  },
+  {
+    id: "edge-mexico",
+    region: "Mexico City",
+    status: "online",
+    load: 52,
+    capability: "Odysseia arcs",
+  },
+];
+
+const fallbackAnchors: DataAnchor[] = [
+  {
+    id: "anchor-01",
+    location: "Local secure enclave",
+    status: "active",
+    latency: "22 ms",
+    assurance: "Persona + memory stay sovereign",
+  },
+  {
+    id: "anchor-02",
+    location: "Community IPFS mirror",
+    status: "syncing",
+    latency: "140 ms",
+    assurance: "Reveta + Sesame task traces verified",
+  },
+];
+
 export default function Home() {
   const [listening, setListening] = useState(false);
   const [speaking, setSpeaking] = useState(false);
@@ -174,6 +231,10 @@ export default function Home() {
   const [applications, setApplications] = useState<ApplicationFlow[]>(fallbackApplications);
   const [loadingVoice, setLoadingVoice] = useState(false);
   const [personaSaved, setPersonaSaved] = useState(false);
+  const [meshEnabled, setMeshEnabled] = useState(true);
+  const [dataResidency, setDataResidency] = useState("Local-first");
+  const [meshNodes, setMeshNodes] = useState<MeshNode[]>(fallbackMeshNodes);
+  const [anchors, setAnchors] = useState<DataAnchor[]>(fallbackAnchors);
 
   const emotionPalette: Record<ChatMessage["emotion"], string> = useMemo(
     () => ({
@@ -202,6 +263,8 @@ export default function Home() {
     fetchOrFallback<Opportunity[]>("/api/orchestration/reveta", fallbackOpportunities, setOpportunities);
     fetchOrFallback<Arc[]>("/api/orchestration/arcs", fallbackArcs, setArcs);
     fetchOrFallback<ApplicationFlow[]>("/api/orchestration/applications", fallbackApplications, setApplications);
+    fetchOrFallback<MeshNode[]>("/api/orchestration/mesh", fallbackMeshNodes, setMeshNodes);
+    fetchOrFallback<DataAnchor[]>("/api/orchestration/anchors", fallbackAnchors, setAnchors);
   }, []);
 
   useEffect(() => {
@@ -272,7 +335,7 @@ export default function Home() {
             <p className="text-sm uppercase tracking-[0.3em] text-indigo-200">Venus experience</p>
             <h1 className="text-4xl md:text-5xl font-black text-white drop-shadow-sm">Real-time, emotion-aware orchestration</h1>
             <p className="mt-3 text-indigo-100/80 max-w-2xl">
-              Voice-first guidance, Sesame tasking, Reveta matches, and Odysseia arcs—stitched into a single responsive console with narrative tone intact.
+              Voice-first guidance, Sesame tasking, Reveta matches, and Odysseia arcs—stitched into a single responsive console with narrative tone intact and a sovereign mesh that keeps data close.
             </p>
           </div>
           <div className="flex items-center gap-3 bg-black/30 border border-indigo-900/30 rounded-2xl px-4 py-3">
@@ -386,6 +449,114 @@ export default function Home() {
             </button>
             {personaSaved && <p className="text-xs text-emerald-200">Persona synced with memory orchestrator.</p>}
           </form>
+        </div>
+      </section>
+
+      <section
+        id="decentralized"
+        className="grid grid-cols-1 xl:grid-cols-3 gap-6 rounded-3xl border border-indigo-900/40 bg-gradient-to-br from-slate-95
+0 via-indigo-950 to-slate-900 shadow-2xl p-6"
+      >
+        <div className="xl:col-span-2 space-y-4">
+          <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div>
+              <p className="text-xs uppercase tracking-[0.3em] text-indigo-200">Decentralized orchestration</p>
+              <h2 className="text-2xl md:text-3xl font-bold text-white">Mesh control + sovereignty</h2>
+              <p className="text-sm text-indigo-100/80 max-w-2xl">
+                Keep Venus responsive while honoring local-first storage, mirrored anchors, and shared execution across regions.
+              </p>
+            </div>
+            <div className="flex gap-3" role="group" aria-label="Mesh configuration">
+              <button
+                type="button"
+                onClick={() => setMeshEnabled(prev => !prev)}
+                aria-pressed={meshEnabled}
+                className={`rounded-xl border px-4 py-3 text-left text-sm font-semibold transition focus-visible:outline focus-vi
+sible:ring-2 focus-visible:ring-pink-400 ${
+                  meshEnabled
+                    ? "bg-pink-900/30 border-pink-700 text-pink-100"
+                    : "bg-slate-900 border-slate-800 text-slate-100"
+                }`}
+              >
+                {meshEnabled ? "Mesh active" : "Mesh paused"}
+                <p className="text-[11px] font-normal opacity-80">Autonomous routing across Venus edges</p>
+              </button>
+              <label className="block text-sm text-indigo-100" htmlFor="residency">
+                <span className="sr-only">Data residency preference</span>
+                <select
+                  id="residency"
+                  value={dataResidency}
+                  onChange={e => setDataResidency(e.target.value)}
+                  className="rounded-xl border border-slate-800 bg-slate-900 px-4 py-3 text-sm focus-visible:outline focus-visibl
+e:ring-2 focus-visible:ring-indigo-400"
+                >
+                  <option>Local-first</option>
+                  <option>Hybrid mesh</option>
+                  <option>Cloud assist</option>
+                </select>
+                <p className="mt-1 text-[11px] text-indigo-100/70">Sovereignty lane: {dataResidency}</p>
+              </label>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-3" role="list" aria-label="Mesh nodes">
+            {meshNodes.map(node => (
+              <div key={node.id} className="rounded-2xl border border-slate-800 bg-black/30 px-4 py-3 space-y-2" role="listitem">
+                <div className="flex items-center justify-between">
+                  <p className="text-sm font-semibold text-white">{node.region}</p>
+                  <span
+                    className={`text-[11px] px-2 py-1 rounded-full border ${
+                      node.status === "online"
+                        ? "border-emerald-700 bg-emerald-900/30 text-emerald-100"
+                        : node.status === "degraded"
+                          ? "border-amber-700 bg-amber-900/30 text-amber-100"
+                          : "border-slate-700 bg-slate-900 text-slate-100"
+                    }`}
+                  >
+                    {node.status}
+                  </span>
+                </div>
+                <p className="text-xs text-indigo-100/80">{node.capability}</p>
+                <div className="flex items-center justify-between text-[11px] text-indigo-200/80">
+                  <span>Node · {node.id}</span>
+                  <span>Load · {node.load}%</span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="space-y-3 rounded-2xl border border-indigo-900/40 bg-slate-950/80 p-4">
+          <div className="flex items-center justify-between">
+            <h3 className="text-xl font-bold text-white">Anchors & proofs</h3>
+            <span className="text-[11px] text-indigo-200">Decentralized storage</span>
+          </div>
+          <p className="text-sm text-indigo-100/80">
+            Routing keeps your persona, memory, and task traces pinned to local or community-owned anchors.
+          </p>
+          <div className="space-y-3" role="list" aria-label="Anchors">
+            {anchors.map(anchor => (
+              <div key={anchor.id} className="rounded-xl border border-slate-800 bg-slate-900/70 px-4 py-3" role="listitem">
+                <div className="flex items-center justify-between">
+                  <p className="text-sm font-semibold text-white">{anchor.location}</p>
+                  <span
+                    className={`text-[11px] px-2 py-1 rounded-full border ${
+                      anchor.status === "active"
+                        ? "border-emerald-700 bg-emerald-900/30 text-emerald-100"
+                        : "border-amber-700 bg-amber-900/30 text-amber-100"
+                    }`}
+                  >
+                    {anchor.status}
+                  </span>
+                </div>
+                <p className="text-xs text-indigo-100/80">{anchor.assurance}</p>
+                <div className="flex items-center justify-between text-[11px] text-indigo-200/80">
+                  <span>Anchor · {anchor.id}</span>
+                  <span>Latency · {anchor.latency}</span>
+                </div>
+              </div>
+            ))}
+          </div>
         </div>
       </section>
 

--- a/odysseia-frontend/lib/orchestrationData.ts
+++ b/odysseia-frontend/lib/orchestrationData.ts
@@ -1,0 +1,192 @@
+export type Task = {
+  id: string;
+  name: string;
+  status: "waiting" | "running" | "complete";
+  eta: string;
+  impact: string;
+};
+
+export type Opportunity = {
+  id: string;
+  title: string;
+  org: string;
+  fitScore: number;
+  summary: string;
+  tags: string[];
+};
+
+export type Arc = {
+  id: string;
+  title: string;
+  stage: string;
+  guidance: string;
+  emphasis: string;
+};
+
+export type ApplicationFlow = {
+  id: string;
+  name: string;
+  destination: string;
+  steps: string[];
+  status: "configured" | "in-flight" | "delivered";
+  lastAction: string;
+};
+
+export type MeshNode = {
+  id: string;
+  region: string;
+  status: "online" | "degraded" | "offline";
+  load: number;
+  capability: string;
+};
+
+export type DataAnchor = {
+  id: string;
+  location: string;
+  status: "active" | "syncing";
+  latency: string;
+  assurance: string;
+};
+
+export const fallbackTasks: Task[] = [
+  {
+    id: "sesame-01",
+    name: "Profile vector refresh",
+    status: "running",
+    eta: "45s",
+    impact: "Aligning persona embeddings with live context",
+  },
+  {
+    id: "sesame-02",
+    name: "Signal triage",
+    status: "waiting",
+    eta: "2m",
+    impact: "Prioritizing high-signal threads for Venus guidance",
+  },
+  {
+    id: "sesame-03",
+    name: "Memory stitch",
+    status: "complete",
+    eta: "0s",
+    impact: "Linked recent sessions into persistent narrative",
+  },
+];
+
+export const fallbackOpportunities: Opportunity[] = [
+  {
+    id: "reveta-01",
+    title: "UNDP Youth Innovation Fellowship",
+    org: "UNDP",
+    fitScore: 92,
+    summary: "Global social impact residency seeking narrative-first builders.",
+    tags: ["UNDP", "Global", "Impact", "Remote"],
+  },
+  {
+    id: "reveta-02",
+    title: "Notion AI Templates Partner",
+    org: "Notion",
+    fitScore: 88,
+    summary: "Build guided workspaces that ship with emotion-aware copilots.",
+    tags: ["Notion", "Builder", "Templates", "Revenue"],
+  },
+  {
+    id: "reveta-03",
+    title: "City Lab Residency",
+    org: "Civic Futures",
+    fitScore: 79,
+    summary: "Prototype neighborhood-scale storytelling pilots with local partners.",
+    tags: ["Local", "Pilot", "Story", "Field"],
+  },
+];
+
+export const fallbackArcs: Arc[] = [
+  {
+    id: "arc-01",
+    title: "Call to Adventure",
+    stage: "Opening",
+    guidance: "Frame your north star, voice what feels unresolved, and let Venus listen.",
+    emphasis: "Attune",
+  },
+  {
+    id: "arc-02",
+    title: "Crossing the Threshold",
+    stage: "Activation",
+    guidance: "Accept a matched opportunity and let Sesame orchestrate first moves.",
+    emphasis: "Commit",
+  },
+  {
+    id: "arc-03",
+    title: "Return with Elixir",
+    stage: "Integration",
+    guidance: "Publish the learnings back into your Notion or UNDP dossier with memory grafts.",
+    emphasis: "Reflect",
+  },
+];
+
+export const fallbackApplications: ApplicationFlow[] = [
+  {
+    id: "flow-01",
+    name: "UNDP application",
+    destination: "UNDP Portal",
+    steps: ["Draft narrative", "Collect references", "Submit dossier"],
+    status: "in-flight",
+    lastAction: "Draft synced with Venus guidance",
+  },
+  {
+    id: "flow-02",
+    name: "Notion workspace push",
+    destination: "Notion",
+    steps: ["Assemble page", "Embed memory", "Share with team"],
+    status: "configured",
+    lastAction: "Awaiting approval to publish to shared space",
+  },
+  {
+    id: "flow-03",
+    name: "Arc export",
+    destination: "Odysseia archive",
+    steps: ["Collate transcripts", "Tag emotions", "Publish story"],
+    status: "delivered",
+    lastAction: "Story released with emotion markers",
+  },
+];
+
+export const fallbackMeshNodes: MeshNode[] = [
+  {
+    id: "edge-paris",
+    region: "Paris",
+    status: "online",
+    load: 34,
+    capability: "Voice + chat",
+  },
+  {
+    id: "edge-nairobi",
+    region: "Nairobi",
+    status: "degraded",
+    load: 68,
+    capability: "Reveta scoring",
+  },
+  {
+    id: "edge-mexico",
+    region: "Mexico City",
+    status: "online",
+    load: 52,
+    capability: "Odysseia arcs",
+  },
+];
+
+export const fallbackAnchors: DataAnchor[] = [
+  {
+    id: "anchor-01",
+    location: "Local secure enclave",
+    status: "active",
+    latency: "22 ms",
+    assurance: "Persona + memory stay sovereign",
+  },
+  {
+    id: "anchor-02",
+    location: "Community IPFS mirror",
+    status: "syncing",
+    latency: "140 ms",
+    assurance: "Reveta + Sesame task traces verified",
+  },
+];

--- a/odysseia-frontend/next-env.d.ts
+++ b/odysseia-frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/odysseia-frontend/tsconfig.json
+++ b/odysseia-frontend/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "esnext",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -14,8 +18,22 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "types": ["node"]
+    "types": [
+      "node"
+    ],
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
- type metadata with Next.js Metadata helper for clearer layout typing
- replace nested main element with a div to keep page semantics valid within the layout wrapper

## Testing
- npm run lint (blocked by interactive ESLint configuration prompt in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ccf311090832c927b47e2ecd8198c)